### PR TITLE
Compiler build workflow (CI)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: compiler-build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2
+
+    - name: install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bison cmake flex gcc make
+
+    - name: cmake generation
+      run: |
+         cmake -S . -B bin
+
+    - name: make build
+      run: |
+        cd bin
+        make


### PR DESCRIPTION
### Descripción
Se propone agregar un flujo de trabajo de integración continua para compilar el proyecto.

###  Motivación
Reducir la introducción de errores, tanto durante el desarrollo como en la entrega parcial y/o final.

Especialmente útil para usuarios con Windows donde ha pasado que MSVC compila correctamente el proyecto y determina que no necesita ciertos `#include` implicitamente, lo cual deriva en que el programa no pueda ser compilado en otros entornos que exige la cátedra (e.g _pampero_).